### PR TITLE
Fixing radius bug on Safari

### DIFF
--- a/src/components/profile/profile.component.tsx
+++ b/src/components/profile/profile.component.tsx
@@ -28,7 +28,9 @@ function Profile({ name, title, profilePicture, socials }: ProfileType) {
               borderRadius: '50%',
               borderStyle: 'solid',
               borderWidth: '2px',
-              borderColor: 'var(--chakra-colors-simonyi_zold)'
+              borderColor: 'var(--chakra-colors-simonyi_zold)',
+              position: 'relative',
+              zIndex: 0
             }}
           />
         ) : (


### PR DESCRIPTION
There was a bug on iPadOS (iOS) devices where the image's radius looked different from Windows/Android devices. This PR fixes this issue.

![image](https://user-images.githubusercontent.com/4851436/221385129-1887b7a7-41aa-49e8-a44d-e174be15926a.png)
